### PR TITLE
Separate cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ json-schema-generator path/to/input.json -o path/to/output.json
 #### JSON URL
 json-schema-generator https://sample.com/path/to/input.json --jsondir ./source/backup -o ./path/to/dir/
 #### JSON STDIN | STDOUT
-cat input.json | json-schema-generator - > output.json
+cat input.json | json-schema-generator > output.json
 ```
 
 ### Install as lib (NPM)
@@ -48,13 +48,13 @@ schemaObj = jsonSchemaGenerator(json);
 
 ### Cli usage
 ```
-Usage: node ./bin/cli.js <target>|--url <url>|--file <file>|--stdin
+Usage: json-schema-generator <target>|--url <url>|--file <file>|--stdin
 
 If <target> is specified, it is interpreted as follows: a protocol (like http://) 
-means url; a dash (-) means stdin; anything else is treated as path to a local file.
+means url; anything else is treated as path to a local file.
 
 Options:
-  --stdin, -0      Use stdin as input.                                              
+  --stdin          Use stdin as input.                                              
   --url            Remote json document to use as input.                            
   --file           Local json document to use as input.                             
   --schemadir, -o  Directory (or file, if ending with .json) where the schema will

--- a/README.md
+++ b/README.md
@@ -48,10 +48,11 @@ schemaObj = jsonSchemaGenerator(json);
 
 ### Cli usage
 ```
-Usage: json-schema-generator <target>|--url <url>|--file <file>|--stdin
+Usage: json-schema-generator [<target>|--url <url>|--file <file>|--stdin]
 
 If <target> is specified, it is interpreted as follows: a protocol (like http://) 
-means url; anything else is treated as path to a local file.
+means url; anything else is treated as path to a local file. 
+If no input file is specified and stdin is provided, stdin is used.
 
 Options:
   --stdin          Use stdin as input.                                              

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -11,7 +11,7 @@ var usageText = [
 		"Usage: $0 <target>|--url <url>|--file <file>|--stdin",
 		"",
 		"If <target> is specified, it is interpreted as follows: a protocol (like http://) ",
-		"means url; a dash (-) means stdin; anything else is treated as path to a local file."
+		"means url; anything else is treated as path to a local file."
 	].join('\n'),
 	optimist = require('optimist')
 		.usage(usageText)
@@ -19,7 +19,6 @@ var usageText = [
 		.boolean(['pretty','force', 'stdin'])
 		.default('pretty', true)
 		.describe('stdin', 'Use stdin as input.')
-		.alias('stdin', '0')
 		.describe('url', 'Remote json document to use as input.')
 		.describe('file', 'Local json document to use as input.')
 		.describe('schemadir', 'Directory (or file, if ending with .json) where the schema will be stored.')
@@ -84,9 +83,6 @@ function createConfig(argv) {
 						// if url thinks it has a host then I agree
 						config.src.type = IOType.URL;
 						config.src.path = argVal.href;
-					} else if (argVal.path === '-') {
-						// dash should mean stdin right?
-						config.src.type = IOType.STDIN;
 					} else {
 						// all else is local file dest
 						config.src.type = IOType.FILE;
@@ -120,6 +116,9 @@ function createConfig(argv) {
 	}
 	if (config.src.path) {
 		config.dest.defaultFileName = config.copy.defaultFileName = getName(config.src.path);
+	}
+	if (!config.src.type && !process.stdin.isTTY) {
+		config.src.type = IOType.STDIN;
 	}
 	return config;
 }

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -8,10 +8,11 @@ var url = require('url'),
 
 var usageText = [
 		//"Extract a json-schema from a json document.",
-		"Usage: $0 <target>|--url <url>|--file <file>|--stdin",
+		"Usage: $0 [<target>|--url <url>|--file <file>|--stdin]",
 		"",
 		"If <target> is specified, it is interpreted as follows: a protocol (like http://) ",
-		"means url; anything else is treated as path to a local file."
+		"means url; anything else is treated as path to a local file. ",
+		"If no input file is specified and stdin is provided, stdin is used."
 	].join('\n'),
 	optimist = require('optimist')
 		.usage(usageText)

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "json-schema-generator",
-  "version": "1.1.15",
+  "version": "1.1.16",
   "dependencies": {
     "json-promise": {
       "version": "1.1.8",
@@ -42,6 +42,11 @@
           "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
         }
       }
+    },
+    "pretty-data": {
+      "version": "0.40.0",
+      "from": "pretty-data@*",
+      "resolved": "https://registry.npmjs.org/pretty-data/-/pretty-data-0.40.0.tgz"
     },
     "request": {
       "version": "2.51.0",
@@ -165,12 +170,12 @@
             },
             "asn1": {
               "version": "0.1.11",
-              "from": "asn1@0.1.11",
+              "from": "http://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
               "resolved": "http://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
             },
             "ctype": {
               "version": "0.5.3",
-              "from": "ctype@0.5.3",
+              "from": "http://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
               "resolved": "http://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
             }
           }

--- a/test/cli-test.js
+++ b/test/cli-test.js
@@ -45,7 +45,7 @@ describe('Cli', function() {
 		inputRemotePath = null;
 	});
 	it('Should be able to read stdin', function() {
-		schemaJSON = JSON.parse(runCli('-', inputJSONString)[0]);
+		schemaJSON = JSON.parse(runCli([], inputJSONString)[0]);
 		expect(inputJSON).to.be.jsonSchema(schemaJSON);
 	});
 	it('Should be able to write to a file', function() {

--- a/test/cli-test.js
+++ b/test/cli-test.js
@@ -31,7 +31,7 @@ var inputLocalPath ='./test/fixtures/json/valid.json',
 	inputJSONString = fs.readFileSync(inputLocalPath, 'utf8'),
 	inputJSON = JSON.parse(inputJSONString);
 
-var schemaJSON;
+var schemaJSON, copyJSON;
 
 describe('Cli', function() {
 	it('Should be able to read a local file', function() {
@@ -64,6 +64,13 @@ describe('Cli', function() {
 		runCli([inputLocalPath, '--schemadir', './test/fixtures/var/']);
 		schemaJSON = JSON.parse(fs.readFileSync('./test/fixtures/var/valid.json'));
 		expect(inputJSON).to.be.jsonSchema(schemaJSON);
+		fs.unlinkSync('./test/fixtures/var/valid.json');
+		fs.rmdirSync('./test/fixtures/var');
+	});
+	it('Should be able to create a copy of source', function() {
+		runCli([inputLocalPath, '--jsondir', './test/fixtures/var/']);
+		copyJSON = JSON.parse(fs.readFileSync('./test/fixtures/var/valid.json'));
+		expect(inputJSON).to.be.deep.equal(copyJSON);
 		fs.unlinkSync('./test/fixtures/var/valid.json');
 		fs.rmdirSync('./test/fixtures/var');
 	});


### PR DESCRIPTION
With updated shrinkwrap. I've tested it (with `-g`) from my own repository, it installs pretty-data. 

I've also just found that nodejs can detect stdin usage, which makes an argument like `-` unnecessary. So, with this, you can use `cat input.json | json-schema-generator > output.json` without any additonal argument. I've updated the help text, README and test case for this. It should still be backwards compatible. 

Also, could you bump the version and `npm publish` the result? If only for the sake of fixing the installation of dependencies for other users. 