### PR TITLE
Fix utils.Array -> utils.isArray

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -34,7 +34,7 @@ AST.prototype.generateHash = function(value) {
  if (utils.isObject(value)) {
     var keys = Object.keys(value);
     return crypto.createHash("md5").update(JSON.stringify(keys)).digest("hex");
-  } else if (utils.Array(value)) {
+  } else if (utils.isArray(value)) {
     return crypto.createHash("md5").update(JSON.stringify(value)).digest("hex");
   } else {
     return crypto.createHash("md5").update(value).digest("hex");


### PR DESCRIPTION
currently hitting this:

    Uncaught TypeError: utils.Array is not a function
      at AST.generateHash (node_modules/json-schema-generator/lib/ast.js:37:20)
      at AST.isAllSimilarObjects (node_modules/json-schema-generator/lib/ast.js:57:21)
      at AST.buildArrayTree (node_modules/json-schema-generator/lib/ast.js:130:24)

I think this was meant to be isArray. Let me know if I'm wrong.